### PR TITLE
Bugfix: Duplicated Browser#newContext() call

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
+++ b/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
@@ -129,7 +129,7 @@ public class PlaywrightClient extends AbstractCrawlerClient {
             playwright = Playwright.create(new Playwright.CreateOptions().setEnv(options));
             browser = getBrowserType(playwright).launch(launchOptions);
             browserContext = browser.newContext(newContextOptions);
-            page = browser.newContext(newContextOptions).newPage();
+            page = browserContext.newPage();
         } catch (final Exception e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Failed to create Playwright instance.", e);


### PR DESCRIPTION
Fixes a bug where the created browserContext wasn't used to open new browser page.