### PR TITLE
Update parent POM version to 15.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.0.0-SNAPSHOT</version>
+		<version>15.0.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
This update finalizes the release of version 15.0.0 by updating the version numbers of key dependencies and components in the pom.xml file from 15.0.0-SNAPSHOT to 15.0.0. This includes fess.version, crawler.version, crawler.playwright.version, and suggest.version.
