### PR TITLE
Update fess-parent version to 15.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0-SNAPSHOT</version>
+		<version>15.1.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
This pull request updates the parent POM version in the fess-crawler-playwright project from 15.1.0-SNAPSHOT to the final 15.1.0 release. This aligns the project with the stable release version of fess-parent and prepares it for production use.
