### PR TITLE
Update parent POM version from snapshot to release 15.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0-SNAPSHOT</version>
+		<version>15.2.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
This pull request updates the parent dependency version in the `pom.xml` file to use the stable release instead of the snapshot version.

* Dependency management:
  * Changed the parent `fess-parent` version from `15.2.0-SNAPSHOT` to `15.2.0` in `pom.xml`, switching from a development snapshot to the official release version.