### PR TITLE
refactor(test): migrate test utilities from Jetty 6 to Jetty 12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,9 +144,15 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty</artifactId>
-			<version>6.1.26</version>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>12.0.32</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-client</artifactId>
+			<version>12.0.32</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/test/java/org/codelibs/fess/crawler/util/CrawlerAuthenticationServer.java
+++ b/src/test/java/org/codelibs/fess/crawler/util/CrawlerAuthenticationServer.java
@@ -13,53 +13,33 @@
  * either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- */
 package org.codelibs.fess.crawler.util;
 
-import java.io.IOException;
-import java.security.Principal;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
-import org.mortbay.jetty.Request;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.handler.ContextHandler;
-import org.mortbay.jetty.security.BasicAuthenticator;
-import org.mortbay.jetty.security.Constraint;
-import org.mortbay.jetty.security.ConstraintMapping;
-import org.mortbay.jetty.security.DigestAuthenticator;
-import org.mortbay.jetty.security.FormAuthenticator;
-import org.mortbay.jetty.security.HashUserRealm;
-import org.mortbay.jetty.security.SecurityHandler;
-import org.mortbay.jetty.servlet.DefaultServlet;
-import org.mortbay.jetty.servlet.ServletHandler;
-import org.mortbay.jetty.servlet.ServletHolder;
-import org.mortbay.jetty.servlet.SessionHandler;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
 
 /**
- * A mock authentication server implementation for testing purposes, using Jetty 6.
- * Supports Basic, Digest & Form authentication method
+ * A mock authentication server implementation for testing purposes, using Jetty 12.
+ * Supports Basic, Digest &amp; Form authentication method
  */
 public class CrawlerAuthenticationServer {
     private static final Logger logger = LogManager.getLogger(CrawlerAuthenticationServer.class);
@@ -71,21 +51,26 @@ public class CrawlerAuthenticationServer {
     /** Value of authenticity_token input entry that will be used for verification when FORM authMethod is used */
     private static final String TOKEN_VALUE_FOR_FORM_AUTH = "Abcdef1234!@#$";
 
+    private static final String REALM = "test";
+
     private final Server server = new Server();
-    private final HashUserRealm userRealm = new AuthenticityTokenHashUserRealm();
+    private final Map<String, String> userCredentials = new ConcurrentHashMap<>();
     private final AtomicReference<AuthMethod> currentAuthMethod = new AtomicReference<>();
+
+    // Simple session store for form authentication
+    private final Set<String> authenticatedSessions = ConcurrentHashMap.newKeySet();
 
     private int port = 7070;
 
-    public void setPort(int port) {
+    public void setPort(final int port) {
         this.port = port;
     }
 
-    public void addUser(String userName, Object password) {
+    public void addUser(final String userName, final Object password) {
         if (logger.isDebugEnabled()) {
             logger.debug("Adding user '{}' to authentication realm", userName);
         }
-        this.userRealm.put(userName, password);
+        this.userCredentials.put(userName, password.toString());
     }
 
     public void setAuthMethod(final AuthMethod authMethod) {
@@ -93,9 +78,9 @@ public class CrawlerAuthenticationServer {
             logger.info("Setting authentication method to: {}", authMethod);
         }
         switch (authMethod) {
-        case BASIC -> useBasicAuth();
-        case DIGEST -> useDigestAuth();
-        case FORM -> useFormAuth();
+        case BASIC -> server.setHandler(new BasicAuthHandler());
+        case DIGEST -> server.setHandler(new DigestAuthHandler());
+        case FORM -> server.setHandler(new FormAuthHandler());
         }
         this.currentAuthMethod.set(authMethod);
     }
@@ -111,17 +96,16 @@ public class CrawlerAuthenticationServer {
                         currentAuthMethod.get());
             }
 
-            // add port to server
-            final var connector = new SocketConnector();
+            final var connector = new ServerConnector(server);
             connector.setPort(this.port);
-            this.server.setConnectors(ArrayUtils.toArray(connector));
+            server.addConnector(connector);
 
             server.start();
 
             if (logger.isInfoEnabled()) {
                 logger.info("CrawlerAuthenticationServer started successfully on port {}", port);
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new CrawlerSystemException("Failed to start CrawlerAuthenticationServer on port " + port, e);
         }
     }
@@ -135,118 +119,137 @@ public class CrawlerAuthenticationServer {
             if (logger.isInfoEnabled()) {
                 logger.info("CrawlerAuthenticationServer stopped successfully on port {}", port);
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new CrawlerSystemException("Failed to stop CrawlerAuthenticationServer on port " + port, e);
         }
     }
 
-    private void useBasicAuth() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Configuring Basic authentication");
-        }
-
-        final var servletSuccess = new AuthSuccessServlet();
-
-        final var contextHandler = new ContextHandler("/");
-        final var sessionHandler = new SessionHandler();
-        final var securityHandler = new SecurityHandler();
-        final var servletHandler = new ServletHandler();
-
-        servletHandler.addServletWithMapping(new ServletHolder(servletSuccess), "/*");
-        securityHandler.setHandler(servletHandler);
-        sessionHandler.setHandler(securityHandler);
-        contextHandler.setHandler(sessionHandler);
-        securityHandler.setUserRealm(this.userRealm);
-
-        final var constraint = new Constraint(Constraint.__BASIC_AUTH, Constraint.ANY_ROLE);
-        constraint.setAuthenticate(true);
-        final var constraintMapping = new ConstraintMapping();
-        constraintMapping.setConstraint(constraint);
-        constraintMapping.setPathSpec("/*");
-        securityHandler.setConstraintMappings(ArrayUtils.toArray(constraintMapping));
-
-        securityHandler.setAuthenticator(new BasicAuthenticator());
-        this.server.setHandler(contextHandler);
+    private boolean validateCredentials(final String username, final String password) {
+        final String storedPassword = userCredentials.get(username);
+        return storedPassword != null && storedPassword.equals(password);
     }
 
-    private void useDigestAuth() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Configuring Digest authentication");
-        }
-
-        final var servletSuccess = new AuthSuccessServlet();
-
-        final var contextHandler = new ContextHandler("/");
-        final var sessionHandler = new SessionHandler();
-        final var securityHandler = new SecurityHandler();
-        final var servletHandler = new ServletHandler();
-
-        servletHandler.addServletWithMapping(new ServletHolder(servletSuccess), "/*");
-        securityHandler.setHandler(servletHandler);
-        sessionHandler.setHandler(securityHandler);
-        contextHandler.setHandler(sessionHandler);
-        securityHandler.setUserRealm(this.userRealm);
-
-        final var constraint = new Constraint(Constraint.__DIGEST_AUTH, Constraint.ANY_ROLE);
-        constraint.setAuthenticate(true);
-        final var constraintMapping = new ConstraintMapping();
-        constraintMapping.setConstraint(constraint);
-        constraintMapping.setPathSpec("/*");
-        securityHandler.setConstraintMappings(ArrayUtils.toArray(constraintMapping));
-
-        securityHandler.setAuthenticator(new DigestAuthenticator());
-        this.server.setHandler(contextHandler);
-    }
-
-    private void useFormAuth() {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Configuring Form authentication");
-        }
-
-        final var servletSuccess = new AuthSuccessServlet();
-        final var servletPrompt = new AuthFormServlet();
-        final var servletAuthError = new AuthFailedServlet();
-
-        final var contextHandler = new ContextHandler("/");
-        final var sessionHandler = new SessionHandler();
-        final var securityHandler = new SecurityHandler();
-        final var servletHandler = new ServletHandler();
-
-        servletHandler.addServletWithMapping(new ServletHolder(servletSuccess), "/*");
-        servletHandler.addServletWithMapping(new ServletHolder(servletPrompt), "/login");
-        servletHandler.addServletWithMapping(new ServletHolder(servletAuthError), "/error");
-
-        securityHandler.setHandler(servletHandler);
-        sessionHandler.setHandler(securityHandler);
-        contextHandler.setHandler(sessionHandler);
-
-        securityHandler.setUserRealm(this.userRealm);
-
-        final var constraint = new Constraint(Constraint.__FORM_AUTH, Constraint.ANY_ROLE);
-        constraint.setAuthenticate(true);
-        final var constraintMapping = new ConstraintMapping();
-        constraintMapping.setConstraint(constraint);
-        constraintMapping.setPathSpec("/*");
-        securityHandler.setConstraintMappings(ArrayUtils.toArray(constraintMapping));
-
-        final var authenticator = new FormAuthenticator();
-        authenticator.setLoginPage("/login");
-        authenticator.setErrorPage("/error");
-        securityHandler.setAuthenticator(authenticator);
-        this.server.setHandler(contextHandler);
-    }
-
-    private static class AuthSuccessServlet extends DefaultServlet {
+    // =========================================================================
+    //                                                       Basic Auth Handler
+    // =========================================================================
+    private class BasicAuthHandler extends Handler.Abstract {
         @Override
-        protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Authentication successful for request: {}", request.getRequestURI());
+        public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
+            final String authHeaderValue = request.getHeaders().get(HttpHeader.AUTHORIZATION);
+
+            if (authHeaderValue != null && authHeaderValue.startsWith("Basic ")) {
+                final String decoded = new String(Base64.getDecoder().decode(authHeaderValue.substring(6)), StandardCharsets.UTF_8);
+                final String[] parts = decoded.split(":", 2);
+                if (parts.length == 2 && validateCredentials(parts[0], parts[1])) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Basic authentication successful for user '{}'", parts[0]);
+                    }
+                    response.setStatus(200);
+                    Content.Sink.write(response, true, "Authentication successful", callback);
+                    return true;
+                }
             }
-            response.getWriter().append("Authentication successful");
+
+            response.setStatus(401);
+            response.getHeaders().put(HttpHeader.WWW_AUTHENTICATE, "Basic realm=\"" + REALM + "\"");
+            Content.Sink.write(response, true, "", callback);
+            return true;
         }
     }
 
-    private static class AuthFormServlet extends DefaultServlet {
+    // =========================================================================
+    //                                                      Digest Auth Handler
+    // =========================================================================
+    private class DigestAuthHandler extends Handler.Abstract {
+        private final String nonce = UUID.randomUUID().toString();
+
+        @Override
+        public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
+            final String authHeaderValue = request.getHeaders().get(HttpHeader.AUTHORIZATION);
+
+            if (authHeaderValue != null && authHeaderValue.startsWith("Digest ")) {
+                if (validateDigestAuth(authHeaderValue, request.getMethod())) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Digest authentication successful");
+                    }
+                    response.setStatus(200);
+                    Content.Sink.write(response, true, "Authentication successful", callback);
+                    return true;
+                }
+            }
+
+            response.setStatus(401);
+            response.getHeaders().put(HttpHeader.WWW_AUTHENTICATE, "Digest realm=\"" + REALM + "\", nonce=\"" + nonce + "\", qop=\"auth\"");
+            Content.Sink.write(response, true, "", callback);
+            return true;
+        }
+
+        private boolean validateDigestAuth(final String authHeader, final String method) {
+            try {
+                final Map<String, String> params = parseDigestParams(authHeader.substring(7));
+                final String username = params.get("username");
+                final String storedPassword = userCredentials.get(username);
+                if (storedPassword == null) {
+                    return false;
+                }
+
+                final String realm = params.get("realm");
+                final String digestNonce = params.get("nonce");
+                final String uri = params.get("uri");
+                final String nc = params.get("nc");
+                final String cnonce = params.get("cnonce");
+                final String qop = params.get("qop");
+                final String clientResponse = params.get("response");
+
+                final String ha1 = md5Hex(username + ":" + realm + ":" + storedPassword);
+                final String ha2 = md5Hex(method + ":" + uri);
+
+                final String expectedResponse;
+                if ("auth".equals(qop)) {
+                    expectedResponse = md5Hex(ha1 + ":" + digestNonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2);
+                } else {
+                    expectedResponse = md5Hex(ha1 + ":" + digestNonce + ":" + ha2);
+                }
+
+                return expectedResponse.equals(clientResponse);
+            } catch (final Exception e) {
+                logger.warn("Failed to validate digest auth", e);
+                return false;
+            }
+        }
+
+        private Map<String, String> parseDigestParams(final String params) {
+            final Map<String, String> result = new ConcurrentHashMap<>();
+            final String[] pairs = params.split(",\\s*");
+            for (final String pair : pairs) {
+                final int eqIndex = pair.indexOf('=');
+                if (eqIndex > 0) {
+                    final String key = pair.substring(0, eqIndex).trim();
+                    String value = pair.substring(eqIndex + 1).trim();
+                    if (value.startsWith("\"") && value.endsWith("\"")) {
+                        value = value.substring(1, value.length() - 1);
+                    }
+                    result.put(key, value);
+                }
+            }
+            return result;
+        }
+
+        private String md5Hex(final String input) throws Exception {
+            final MessageDigest md = MessageDigest.getInstance("MD5");
+            final byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            final StringBuilder sb = new StringBuilder();
+            for (final byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        }
+    }
+
+    // =========================================================================
+    //                                                        Form Auth Handler
+    // =========================================================================
+    private class FormAuthHandler extends Handler.Abstract {
         private static final String LOGIN_FORM_TEMPLATE = """
                 <!DOCTYPE html>
                 <html lang="en-US">
@@ -267,50 +270,101 @@ public class CrawlerAuthenticationServer {
                 """;
 
         @Override
-        protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Serving login form for request: {}", request.getRequestURI());
+        public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
+            final String path = request.getHttpURI().getPath();
+
+            // Check session cookie
+            final String sessionId = getSessionId(request);
+            if (sessionId != null && authenticatedSessions.contains(sessionId)) {
+                response.setStatus(200);
+                Content.Sink.write(response, true, "Authentication successful", callback);
+                return true;
             }
-            response.getWriter().append(LOGIN_FORM_TEMPLATE.formatted(TOKEN_VALUE_FOR_FORM_AUTH));
+
+            // Serve login form
+            if ("/login".equals(path)) {
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/html;charset=UTF-8");
+                Content.Sink.write(response, true, LOGIN_FORM_TEMPLATE.formatted(TOKEN_VALUE_FOR_FORM_AUTH), callback);
+                return true;
+            }
+
+            // Process login
+            if ("/j_security_check".equals(path) && "POST".equals(request.getMethod())) {
+                return handleLoginPost(request, response, callback);
+            }
+
+            // Serve error page
+            if ("/error".equals(path)) {
+                response.setStatus(200);
+                Content.Sink.write(response, true, "Authentication failed", callback);
+                return true;
+            }
+
+            // Redirect to login
+            response.setStatus(302);
+            response.getHeaders().put(HttpHeader.LOCATION, "/login");
+            callback.succeeded();
+            return true;
         }
-    }
 
-    private static class AuthFailedServlet extends DefaultServlet {
-        @Override
-        protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Authentication failed for request: {}", request.getRequestURI());
-            }
-            response.getWriter().append("Authentication failed");
-        }
-    }
+        private boolean handleLoginPost(final Request request, final Response response, final Callback callback) throws Exception {
+            final String body = Content.Source.asString(request, StandardCharsets.UTF_8);
+            final Map<String, String> params = parseFormParams(body);
 
-    private class AuthenticityTokenHashUserRealm extends HashUserRealm {
-        @Override
-        public Principal authenticate(final String username, final Object credentials, final Request request) {
-            // authenticate normally for all methods other than form
-            final AuthMethod authMethod = CrawlerAuthenticationServer.this.getCurrentAuthMethod();
-            if (authMethod != AuthMethod.FORM) {
+            final String username = params.get("j_username");
+            final String password = params.get("j_password");
+            final String token = params.get("authenticity_token");
+
+            if (StringUtils.equals(token, TOKEN_VALUE_FOR_FORM_AUTH) && validateCredentials(username, password)) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Authenticating user '{}' with {} authentication", username, authMethod);
+                    logger.debug("Form authentication successful for user '{}'", username);
                 }
-                return super.authenticate(username, credentials, request);
-            }
+                final String newSessionId = UUID.randomUUID().toString();
+                authenticatedSessions.add(newSessionId);
 
-            // validate authenticity_token as well for form authentication
-            // Used for testing crawler's token retrieval function
-            final String requestToken = request.getParameter("authenticity_token");
-            if (StringUtils.equals(requestToken, TOKEN_VALUE_FOR_FORM_AUTH)) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Authenticating user '{}' with FORM authentication (token valid)", username);
-                }
-                return super.authenticate(username, credentials, request);
+                response.setStatus(302);
+                response.getHeaders().put(HttpHeader.SET_COOKIE, "JSESSIONID=" + newSessionId + "; Path=/");
+                response.getHeaders().put(HttpHeader.LOCATION, "/");
+                callback.succeeded();
             } else {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Authentication failed for user '{}' - invalid authenticity token", username);
+                    logger.debug("Form authentication failed for user '{}'", username);
                 }
+                response.setStatus(302);
+                response.getHeaders().put(HttpHeader.LOCATION, "/error");
+                callback.succeeded();
+            }
+            return true;
+        }
+
+        private String getSessionId(final Request request) {
+            final String cookieHeader = request.getHeaders().get(HttpHeader.COOKIE);
+            if (cookieHeader == null) {
                 return null;
             }
+            for (final String cookie : cookieHeader.split(";")) {
+                final String trimmed = cookie.trim();
+                if (trimmed.startsWith("JSESSIONID=")) {
+                    return trimmed.substring("JSESSIONID=".length());
+                }
+            }
+            return null;
+        }
+
+        private Map<String, String> parseFormParams(final String body) {
+            final Map<String, String> params = new ConcurrentHashMap<>();
+            if (body == null) {
+                return params;
+            }
+            for (final String pair : body.split("&")) {
+                final String[] kv = pair.split("=", 2);
+                if (kv.length == 2) {
+                    params.put(java.net.URLDecoder.decode(kv[0], StandardCharsets.UTF_8),
+                            java.net.URLDecoder.decode(kv[1], StandardCharsets.UTF_8));
+                }
+            }
+            return params;
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/crawler/util/CrawlerWebProxy.java
+++ b/src/test/java/org/codelibs/fess/crawler/util/CrawlerWebProxy.java
@@ -15,27 +15,23 @@
  */
 package org.codelibs.fess.crawler.util;
 
-import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.bio.SocketConnector;
-import org.mortbay.jetty.servlet.ServletHandler;
-import org.mortbay.jetty.servlet.ServletHolder;
-import org.mortbay.servlet.ProxyServlet;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.Callback;
 
 /**
  * A sample single-threaded proxy server (based on Jetty) for testing purposes.
@@ -53,7 +49,8 @@ public class CrawlerWebProxy {
 
     // Records the last access result
     private final AtomicReference<ProxyAccessStatus> accessResult = new AtomicReference<>(ProxyAccessStatus.NOT_ACCESSED);
-    private final Server proxyServer = new Server();
+    private Server proxyServer;
+    private HttpClient httpClient;
 
     // Ports below 1024 requires sudo permissions on linux.
     private int port = 3128;
@@ -81,12 +78,11 @@ public class CrawlerWebProxy {
 
     public void start() {
         try {
-            // add port to server
-            final SocketConnector connector = new SocketConnector();
-            connector.setPort(this.port);
-            this.proxyServer.setConnectors(ArrayUtils.toArray(connector));
+            httpClient = new HttpClient();
+            httpClient.start();
 
-            attachProxyServlet();
+            proxyServer = new Server(this.port);
+            proxyServer.setHandler(new CrawlerProxyHandler());
             proxyServer.start();
         } catch (final Exception e) {
             throw new CrawlerSystemException(e);
@@ -96,17 +92,10 @@ public class CrawlerWebProxy {
     public void stop() {
         try {
             proxyServer.stop();
+            httpClient.stop();
         } catch (final Exception e) {
             throw new CrawlerSystemException(e);
         }
-    }
-
-    private void attachProxyServlet() {
-        final ServletHandler handler = new ServletHandler();
-        final CrawlerProxyServlet proxyServlet = new CrawlerProxyServlet();
-        final ServletHolder holder = new ServletHolder(proxyServlet);
-        handler.addServletWithMapping(holder, "/*");
-        this.proxyServer.setHandler(handler);
     }
 
     private static String encodeCredentials(final String username, final String password) {
@@ -119,56 +108,65 @@ public class CrawlerWebProxy {
         return "Basic %s".formatted(encodedString);
     }
 
-    private class CrawlerProxyServlet extends ProxyServlet {
+    private class CrawlerProxyHandler extends Handler.Abstract {
         @Override
-        public void service(final ServletRequest req, final ServletResponse res) throws ServletException, IOException {
+        public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
             logger.info("Proxy request received!");
             final String correctAuthHeader = CrawlerWebProxy.this.authHeader.get();
 
             // Allow access if there is no authHeader
             if (StringUtils.isBlank(correctAuthHeader)) {
                 logger.info("No authentication required");
-                grantAccess(req, res);
-                return;
+                grantAccess(request, response, callback);
+                return true;
             }
 
-            if (req instanceof final HttpServletRequest httpRequest && res instanceof final HttpServletResponse httpResponse) {
-                final var requestAuthHeader = httpRequest.getHeader(PROXY_AUTHORIZATION);
+            final var requestAuthHeader = request.getHeaders().get(PROXY_AUTHORIZATION);
 
-                if (requestAuthHeader == null) {
-                    requireAuth(httpResponse);
-                } else if (StringUtils.equals(correctAuthHeader, requestAuthHeader)) {
-                    logger.info("Authentication matches!");
-                    grantAccess(req, res);
-                } else {
-                    denyAccess(httpResponse);
-                }
+            if (requestAuthHeader == null) {
+                requireAuth(response, callback);
+            } else if (StringUtils.equals(correctAuthHeader, requestAuthHeader)) {
+                logger.info("Authentication matches!");
+                grantAccess(request, response, callback);
             } else {
-                res.setContentType("text/html;charset=UTF-8");
-                res.setContentLength(0);
-                res.flushBuffer();
+                denyAccess(response, callback);
             }
+            return true;
         }
 
-        private void grantAccess(final ServletRequest req, final ServletResponse res) throws ServletException, IOException {
+        private void grantAccess(final Request request, final Response response, final Callback callback) {
             logger.info("Access granted!");
             CrawlerWebProxy.this.accessResult.set(ProxyAccessStatus.ACCESS_GRANTED);
-            super.service(req, res);
+            try {
+                final String targetUri = request.getHttpURI().toString();
+                final ContentResponse proxyResponse = httpClient.newRequest(targetUri).method(request.getMethod()).send();
+
+                response.setStatus(proxyResponse.getStatus());
+                final String contentType = proxyResponse.getHeaders().get(HttpHeader.CONTENT_TYPE);
+                if (contentType != null) {
+                    response.getHeaders().put(HttpHeader.CONTENT_TYPE, contentType);
+                }
+                response.write(true, ByteBuffer.wrap(proxyResponse.getContent()), callback);
+            } catch (final Exception e) {
+                logger.warn("Failed to proxy request", e);
+                response.setStatus(502);
+                callback.succeeded();
+            }
         }
 
-        private void denyAccess(final HttpServletResponse httpResponse) throws IOException {
+        private void denyAccess(final Response response, final Callback callback) {
             logger.info("Access denied!");
             CrawlerWebProxy.this.accessResult.set(ProxyAccessStatus.ACCESS_DENIED);
-            httpResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            httpResponse.flushBuffer();
+            response.setStatus(401);
+            callback.succeeded();
         }
 
-        private void requireAuth(final HttpServletResponse httpResponse) throws IOException {
+        private void requireAuth(final Response response, final Callback callback) {
             logger.info("Username and password is required but wasn't provided, prompting client for credentials...");
             CrawlerWebProxy.this.accessResult.set(ProxyAccessStatus.PROMPTED_FOR_CREDENTIALS);
-            httpResponse.setStatus(HttpServletResponse.SC_PROXY_AUTHENTICATION_REQUIRED);
-            httpResponse.setHeader(PROXY_AUTHENTICATE, "Basic realm=\"Enter username and password\"");
-            httpResponse.flushBuffer();
+            response.setStatus(407);
+            response.getHeaders().put(PROXY_AUTHENTICATE, "Basic realm=\"Enter username and password\"");
+            callback.succeeded();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/crawler/util/CrawlerWebServer.java
+++ b/src/test/java/org/codelibs/fess/crawler/util/CrawlerWebServer.java
@@ -16,21 +16,25 @@
 package org.codelibs.fess.crawler.util;
 
 import java.io.File;
+import java.nio.file.Path;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.io.FileUtil;
 import org.codelibs.core.io.ResourceUtil;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
-import org.mortbay.jetty.Handler;
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.DefaultHandler;
-import org.mortbay.jetty.handler.HandlerList;
-import org.mortbay.jetty.handler.ResourceHandler;
-import org.mortbay.jetty.nio.SelectChannelConnector;
-import org.mortbay.jetty.security.SslSocketConnector;
-import org.mortbay.log.Log;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 /**
  * @author shinsuke
@@ -60,20 +64,13 @@ public class CrawlerWebServer {
             logger.debug("Initializing CrawlerWebServer on port {} with document root: {}", port, docRoot.getAbsolutePath());
         }
 
-        server = new Server();
+        server = new Server(port);
 
-        // Bind to all interfaces (dual-stack: IPv4 and IPv6)
-        final SelectChannelConnector connector = new SelectChannelConnector();
-        connector.setPort(port);
-        server.addConnector(connector);
-
-        final ResourceHandler resource_handler = new ResourceHandler();
-        resource_handler.setWelcomeFiles(new String[] { "index.html" });
-        resource_handler.setResourceBase(docRoot.getAbsolutePath());
-        Log.info("serving " + resource_handler.getBaseResource());
-        final HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] { resource_handler, new DefaultHandler() });
-        server.setHandler(handlers);
+        final ResourceHandler resourceHandler = new ResourceHandler();
+        resourceHandler.setWelcomeFiles("index.html");
+        resourceHandler.setBaseResource(ResourceFactory.of(resourceHandler).newResource(Path.of(docRoot.getAbsolutePath())));
+        logger.info("serving {}", docRoot.getAbsolutePath());
+        server.setHandler(new Handler.Sequence(resourceHandler, new DefaultHandler()));
 
         if (logger.isDebugEnabled()) {
             logger.debug("CrawlerWebServer initialized successfully");
@@ -98,16 +95,23 @@ public class CrawlerWebServer {
                 logger.debug("Using keystore file: {}", certFilePath);
             }
 
-            // Ssl handler - dual-stack support (IPv4 and IPv6)
-            final SslSocketConnector sslSocketConnector = new SslSocketConnector();
-            sslSocketConnector.setKeystore(certFilePath);
-            sslSocketConnector.setTruststore(certFilePath);
-            sslSocketConnector.setPassword("password");
-            sslSocketConnector.setKeyPassword("password");
-            sslSocketConnector.setTrustPassword("password");
-            sslSocketConnector.setPort(port);
+            final SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+            sslContextFactory.setKeyStorePath(certFilePath);
+            sslContextFactory.setKeyStorePassword("password");
+            sslContextFactory.setKeyManagerPassword("password");
+            sslContextFactory.setTrustStorePath(certFilePath);
+            sslContextFactory.setTrustStorePassword("password");
 
-            server.setConnectors(ArrayUtils.toArray(sslSocketConnector));
+            final HttpConfiguration httpsConfig = new HttpConfiguration();
+            final SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+            secureRequestCustomizer.setSniHostCheck(false);
+            httpsConfig.addCustomizer(secureRequestCustomizer);
+
+            final ServerConnector sslConnector = new ServerConnector(server, new SslConnectionFactory(sslContextFactory, "http/1.1"),
+                    new HttpConnectionFactory(httpsConfig));
+            sslConnector.setPort(port);
+
+            server.setConnectors(new Connector[] { sslConnector });
 
             if (logger.isDebugEnabled()) {
                 logger.debug("TLS configuration completed");


### PR DESCRIPTION
## Summary
Migrate all test utility classes from the deprecated Jetty 6 (`org.mortbay.jetty` 6.1.26) to Jetty 12 (`org.eclipse.jetty` 12.0.32), modernizing the test infrastructure to use current APIs.

## Changes Made
- **pom.xml**: Replace `org.mortbay.jetty:jetty:6.1.26` with `org.eclipse.jetty:jetty-server:12.0.32` and `org.eclipse.jetty:jetty-client:12.0.32`
- **CrawlerWebServer**: Migrate to Jetty 12 `Server`, `ServerConnector`, `ResourceHandler`, `Handler.Sequence`, and `SslContextFactory` APIs. Replace `SslSocketConnector` with `SslConnectionFactory`/`HttpConnectionFactory` chain.
- **CrawlerAuthenticationServer**: Replace Jetty 6's `SecurityHandler`/`Constraint`/`HashUserRealm` infrastructure with custom `Handler.Abstract` implementations for Basic, Digest, and Form authentication. Implement digest validation manually with MD5 computation.
- **CrawlerWebProxy**: Replace `ProxyServlet` (removed in Jetty 12) with a `Handler.Abstract` that uses Jetty `HttpClient` for request forwarding.

## Testing
- All existing tests should continue to pass since only the test utility internals changed
- Run `mvn test` to verify all authentication, proxy, and web server tests work correctly

## Breaking Changes
- None (test utilities only, no production code changes)

## Additional Notes
- Jetty 6 (`org.mortbay.jetty`) has been EOL for many years; Jetty 12 is the current LTS
- The `javax.servlet` API references are removed in favor of Jetty 12's native handler API
- Duplicate license header in CrawlerAuthenticationServer was cleaned up