### PR TITLE
Update fess-parent version to 15.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.6.0-SNAPSHOT</version>
+		<version>15.6.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
Update the `fess-parent` dependency from `15.6.0-SNAPSHOT` to the `15.6.0` release version.

## Changes Made
- Updated `pom.xml` parent version from `15.6.0-SNAPSHOT` to `15.6.0`

## Testing
- No functional changes; dependency version bump only
- CI build will validate compatibility with the released parent POM

## Breaking Changes
- None

## Additional Notes
- This aligns the project with the stable `fess-parent` 15.6.0 release