### PR TITLE
chore(deps): update fess-parent version to 15.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.7.0-SNAPSHOT</version>
+		<version>15.7.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
Update the `fess-parent` dependency from `15.7.0-SNAPSHOT` to the released `15.7.0` version.

## Changes Made
- Bumped the parent POM version in `pom.xml` from `15.7.0-SNAPSHOT` to `15.7.0`

## Testing
- No code changes; relies on existing CI build/test pipeline to validate against the released parent POM

## Breaking Changes
- None

## Additional Notes
- Follows the same convention as the previous parent version bump (#46)