### PR TITLE
fix: synchronize close() with in-flight execute() and preserve content on LoadState timeout

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
+++ b/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
@@ -110,6 +110,16 @@ public class PlaywrightClient extends AbstractCrawlerClient {
 
     private static final Logger logger = LogManager.getLogger(PlaywrightClient.class);
 
+    /**
+     * Guards {@link #init()} (JVM-wide, across every instance) and, nested inside a {@code Page}
+     * monitor, the shared-worker reference-count decrement in {@link #close()}.
+     *
+     * <p><b>Lock-ordering invariant: a {@code Page} monitor (see {@link #close()}/{@link #execute(RequestData)})
+     * is always acquired before this lock, never after.</b> {@link #init()} holds only this lock for
+     * its entire body and never synchronizes on a {@code Page}; keep it that way - acquiring this lock
+     * first and then a {@code Page} monitor anywhere would create the reverse ordering and a real
+     * deadlock risk with {@link #close()}.</p>
+     */
     private static final Object INITIALIZATION_LOCK = new Object();
 
     /**
@@ -227,6 +237,9 @@ public class PlaywrightClient extends AbstractCrawlerClient {
 
     @Override
     public void init() {
+        // Holds only INITIALIZATION_LOCK for this entire method - never nest a `synchronized(page)`
+        // (or any Page monitor) inside it. See the lock-ordering invariant documented on
+        // INITIALIZATION_LOCK's declaration.
         synchronized (INITIALIZATION_LOCK) {
             if (worker != null) {
                 if (logger.isDebugEnabled()) {
@@ -375,6 +388,9 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                 closed = true;
 
                 if (isSharedWorker) {
+                    // Page monitor (pageRef, held above) THEN INITIALIZATION_LOCK - never the reverse
+                    // order. See the lock-ordering invariant documented on INITIALIZATION_LOCK's
+                    // declaration; do not hoist this out to acquire INITIALIZATION_LOCK first.
                     synchronized (INITIALIZATION_LOCK) {
                         final int refCount = SHARED_WORKER_REF_COUNT.decrementAndGet();
                         if (logger.isDebugEnabled()) {

--- a/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
+++ b/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
@@ -68,8 +68,8 @@ import com.microsoft.playwright.BrowserType.LaunchOptions;
 import com.microsoft.playwright.Download;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
-import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.Response;
+import com.microsoft.playwright.TimeoutError;
 import com.microsoft.playwright.options.Cookie;
 import com.microsoft.playwright.options.LoadState;
 import com.microsoft.playwright.options.Proxy;
@@ -276,9 +276,14 @@ public class PlaywrightClient extends AbstractCrawlerClient {
             }
 
             // This instance now holds a live (not-yet-closed) worker/page: a prior close() (if any)
-            // no longer applies. Note this does not weaken the close()-vs-execute() race guard: by
-            // the time init() can observe worker == null and reach here, any earlier close() call on
-            // the previous worker has already fully returned (see close()'s synchronized(pageRef)).
+            // no longer applies. Once a thread has captured a page reference and entered execute()'s
+            // synchronized(page) block, the volatile `closed` check there is reliable against a
+            // concurrent close() (see close()'s synchronized(pageRef)). One narrow, pre-existing gap
+            // remains: execute()'s initial `worker == null` check and its later `worker.getValue4()`
+            // read happen outside any lock, so a close() that fully completes in that exact window can
+            // still surface as a raw NullPointerException instead of this class's own "already closed"
+            // error. Low-severity (both land in the same generic error-handling path upstream) and not
+            // introduced by this flag, so left as-is rather than adding synchronization there.
             closed = false;
 
             if (logger.isDebugEnabled()) {
@@ -581,12 +586,16 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Waiting for LoadState: {}", renderedState);
                     }
-                    page.waitForLoadState(renderedState);
+                    waitForLoadState(page, renderedState);
 
                     if (logger.isDebugEnabled()) {
                         logger.debug("Page reached LoadState: {}", renderedState);
                     }
-                } catch (final PlaywrightException e) {
+                } catch (final TimeoutError e) {
+                    // Only a genuine LoadState timeout is handled here. Other PlaywrightExceptions (e.g.
+                    // the page/browser having crashed or been closed) are deliberately NOT caught: the
+                    // page is no longer in a state we can trust, so they should propagate as real
+                    // failures instead of being treated as "content is fine, just slow to settle".
                     if (downloadRef.get() != null) {
                         // A download may have started as a side effect even though the load-state wait
                         // itself timed out (e.g. a JS-triggered download on a page that is also chatty).
@@ -626,6 +635,21 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                 resetPage(page);
             }
         }
+    }
+
+    /**
+     * Waits for the page to reach the given load state.
+     *
+     * <p>Extracted as its own protected method (rather than calling {@link Page#waitForLoadState(LoadState)}
+     * directly from {@link #execute(RequestData)}) purely as a test seam, so tests can simulate a
+     * non-timeout {@link com.microsoft.playwright.PlaywrightException} (e.g. a page/browser crash) without
+     * needing a real race against Playwright's internals.</p>
+     *
+     * @param page The page.
+     * @param state The load state to wait for.
+     */
+    protected void waitForLoadState(final Page page, final LoadState state) {
+        page.waitForLoadState(state);
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
+++ b/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
@@ -163,6 +163,19 @@ public class PlaywrightClient extends AbstractCrawlerClient {
     protected static final String LAST_MODIFIED_FORMAT = "EEE, dd MMM yyyy HH:mm:ss z";
 
     /**
+     * How long {@link #execute(RequestData)} keeps polling for a download after a LoadState wait
+     * times out with no download detected yet, in milliseconds.
+     *
+     * <p>Deliberately much shorter than {@link #downloadTimeout} (the wait used once a download is
+     * already known to be in progress): a LoadState timeout with no download detected is usually a
+     * genuinely-loaded-but-chatty page, so this short grace poll only needs to catch a download that
+     * fires within a moment of the timeout. Kept as a simple internal constant rather than a
+     * configurable knob, since the timeouts in this class are wired via setters (not init parameters)
+     * and this value is an implementation detail, not something operators need to tune.</p>
+     */
+    protected static final long LOAD_STATE_TIMEOUT_GRACE_PERIOD_MILLIS = 1500L;
+
+    /**
      * A map of options for Playwright.
      */
     protected Map<String, String> options = new HashMap<>();
@@ -204,8 +217,12 @@ public class PlaywrightClient extends AbstractCrawlerClient {
 
     /**
      * The worker instance for Playwright.
+     *
+     * <p>Volatile (like {@link #usingSharedWorker} and {@link #closed}) so that
+     * {@link #execute(RequestData)} can capture it into a local with a single reliable read and a
+     * concurrent {@link #close()} nulling the field cannot cause a torn/inconsistent read.</p>
      */
-    protected Tuple4<Playwright, Browser, BrowserContext, Page> worker;
+    protected volatile Tuple4<Playwright, Browser, BrowserContext, Page> worker;
 
     /**
      * Flag indicating whether this instance is using the shared worker.
@@ -291,12 +308,11 @@ public class PlaywrightClient extends AbstractCrawlerClient {
             // This instance now holds a live (not-yet-closed) worker/page: a prior close() (if any)
             // no longer applies. Once a thread has captured a page reference and entered execute()'s
             // synchronized(page) block, the volatile `closed` check there is reliable against a
-            // concurrent close() (see close()'s synchronized(pageRef)). One narrow, pre-existing gap
-            // remains: execute()'s initial `worker == null` check and its later `worker.getValue4()`
-            // read happen outside any lock, so a close() that fully completes in that exact window can
-            // still surface as a raw NullPointerException instead of this class's own "already closed"
-            // error. Low-severity (both land in the same generic error-handling path upstream) and not
-            // introduced by this flag, so left as-is rather than adding synchronization there.
+            // concurrent close() (see close()'s synchronized(pageRef)). execute() additionally captures
+            // the volatile `worker` field into a single local before dereferencing it, so a close()
+            // that nulls the field in the window after execute()'s initial `worker == null` check
+            // surfaces as this class's own "already closed" CrawlerSystemException rather than a raw
+            // NullPointerException.
             closed = false;
 
             if (logger.isDebugEnabled()) {
@@ -560,7 +576,16 @@ public class PlaywrightClient extends AbstractCrawlerClient {
             logger.debug("Executing request - URL: {}, Method: {}", url, request.getMethod());
         }
 
-        final Page page = worker.getValue4();
+        // Capture the volatile worker into a single local and use only that local below. A concurrent
+        // close() may null the field at any moment; reading it once here means a race can only ever
+        // produce a clean "already closed" error (when the capture reads null) instead of a raw NPE
+        // from re-reading a field that close() nulled between the check above and the dereference.
+        final Tuple4<Playwright, Browser, BrowserContext, Page> currentWorker = worker;
+        if (currentWorker == null) {
+            throw new CrawlerSystemException("PlaywrightClient has already been closed. URL: " + url);
+        }
+
+        final Page page = currentWorker.getValue4();
         final AtomicReference<Response> responseRef = new AtomicReference<>();
         final AtomicReference<Download> downloadRef = new AtomicReference<>();
 
@@ -620,6 +645,22 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                                     + "attempting to handle as file download: {}", e.getMessage());
                         }
                         return waitForDownloadOrFail(page, request, responseRef, downloadRef, e);
+                    }
+                    // No download has been detected YET at the instant of the timeout, but one may fire
+                    // a moment later (e.g. a JS-triggered download that races the load-state timeout).
+                    // Poll briefly - far shorter than downloadTimeout - before giving up. Tradeoff: this
+                    // adds a small, bounded latency (at most LOAD_STATE_TIMEOUT_GRACE_PERIOD_MILLIS) to
+                    // every load-state-timeout fallback, in exchange for catching downloads that surface
+                    // just after the timeout is detected. Unlike waitForDownloadOrFail, a grace period
+                    // that elapses with nothing detected must NOT fail: the page is still successfully
+                    // loaded, so we fall through to returning that content.
+                    final ResponseData gracePeriodDownload =
+                            pollForDownload(page, request, responseRef, downloadRef, LOAD_STATE_TIMEOUT_GRACE_PERIOD_MILLIS);
+                    if (gracePeriodDownload != null) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("A download surfaced within the grace period after the LoadState timeout for URL: {}", url);
+                        }
+                        return gracePeriodDownload;
                     }
                     // No download fired: the page still navigated and rendered successfully, it just
                     // never reached the configured LoadState (e.g. NETWORKIDLE never fires for pages
@@ -688,13 +729,48 @@ public class PlaywrightClient extends AbstractCrawlerClient {
      */
     protected ResponseData waitForDownloadOrFail(final Page page, final RequestData request, final AtomicReference<Response> responseRef,
             final AtomicReference<Download> downloadRef, final Exception cause) {
+        final ResponseData responseData = pollForDownload(page, request, responseRef, downloadRef, downloadTimeout * 1000L);
+        if (responseData != null) {
+            return responseData;
+        }
+
+        final Response response = responseRef.get();
+        final Download download = downloadRef.get();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Failed to access URL - response: {}, download: {}", response != null, download != null);
+        }
+        final String errorDetails = "URL: " + request.getUrl() + ", Response received: " + (response != null) + ", Download started: "
+                + (download != null) + ", Timeout: " + downloadTimeout + "s";
+        throw new CrawlingAccessException("Failed to access the URL. " + errorDetails, cause);
+    }
+
+    /**
+     * Polls for a download to be detected (via the {@code responseRef}/{@code downloadRef} handlers
+     * registered in {@link #execute(RequestData)}), driving Playwright's event loop with
+     * {@link Page#waitForTimeout(double)} using a progressive backoff, for up to {@code maxWaitMillis}.
+     *
+     * <p>Shared by both {@link #waitForDownloadOrFail} (called with the full {@link #downloadTimeout}
+     * once a download is known to be in progress) and {@link #execute(RequestData)}'s short grace-poll
+     * after a LoadState timeout (called with {@link #LOAD_STATE_TIMEOUT_GRACE_PERIOD_MILLIS}). This
+     * method itself never fails on timeout - it returns {@code null} so the caller can decide whether a
+     * miss is a hard failure or a graceful fall-back.</p>
+     *
+     * @param page The page.
+     * @param request The request data.
+     * @param responseRef A reference populated by the page's {@code onResponse} handler, if any.
+     * @param downloadRef A reference populated by the page's {@code onDownload} handler, if any.
+     * @param maxWaitMillis The maximum time to poll, in milliseconds.
+     * @return The response data for the detected download, or {@code null} if a response and a download
+     *         were not both observed within {@code maxWaitMillis}.
+     */
+    protected ResponseData pollForDownload(final Page page, final RequestData request, final AtomicReference<Response> responseRef,
+            final AtomicReference<Download> downloadRef, final long maxWaitMillis) {
         // Wait for download with progressive backoff for responsiveness
         // Start with short intervals, increase over time to balance responsiveness and CPU efficiency
         // Note: page.waitForTimeout() is required to drive Playwright's event loop
-        final long timeoutMs = downloadTimeout * 1000L;
         final long startTime = System.currentTimeMillis();
         long pollInterval = 100L; // Start with 100ms
-        while (System.currentTimeMillis() - startTime < timeoutMs) {
+        while (System.currentTimeMillis() - startTime < maxWaitMillis) {
             if (responseRef.get() != null && downloadRef.get() != null) {
                 break;
             }
@@ -710,7 +786,7 @@ public class PlaywrightClient extends AbstractCrawlerClient {
         }
         if (logger.isDebugEnabled()) {
             final long elapsed = System.currentTimeMillis() - startTime;
-            logger.debug("Download wait completed after {}ms, timeout: {}s", elapsed, downloadTimeout);
+            logger.debug("Download wait completed after {}ms, maxWait: {}ms", elapsed, maxWaitMillis);
         }
 
         final Response response = responseRef.get();
@@ -721,12 +797,7 @@ public class PlaywrightClient extends AbstractCrawlerClient {
             }
             return createResponseData(page, request, response, download);
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug("Failed to access URL - response: {}, download: {}", response != null, download != null);
-        }
-        final String errorDetails = "URL: " + request.getUrl() + ", Response received: " + (response != null) + ", Download started: "
-                + (download != null) + ", Timeout: " + downloadTimeout + "s";
-        throw new CrawlingAccessException("Failed to access the URL. " + errorDetails, cause);
+        return null;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
+++ b/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
@@ -68,6 +68,7 @@ import com.microsoft.playwright.BrowserType.LaunchOptions;
 import com.microsoft.playwright.Download;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.Response;
 import com.microsoft.playwright.options.Cookie;
 import com.microsoft.playwright.options.LoadState;
@@ -203,6 +204,14 @@ public class PlaywrightClient extends AbstractCrawlerClient {
     private volatile boolean usingSharedWorker = false;
 
     /**
+     * Flag indicating whether this instance has been closed.
+     * Checked as the first statement inside execute()'s {@code synchronized (page)} block so that
+     * a thread already in-flight inside execute() (or one that is about to enter its monitor) can
+     * never observe a page/context/browser that close() has torn down out from under it.
+     */
+    private volatile boolean closed = false;
+
+    /**
      * The crawler container instance.
      */
     @Resource
@@ -265,6 +274,12 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                 worker = createPlaywrightWorker();
                 usingSharedWorker = false;
             }
+
+            // This instance now holds a live (not-yet-closed) worker/page: a prior close() (if any)
+            // no longer applies. Note this does not weaken the close()-vs-execute() race guard: by
+            // the time init() can observe worker == null and reach here, any earlier close() call on
+            // the previous worker has already fully returned (see close()'s synchronized(pageRef)).
+            closed = false;
 
             if (logger.isDebugEnabled()) {
                 logger.debug("Playwright initialization completed successfully");
@@ -339,34 +354,44 @@ public class PlaywrightClient extends AbstractCrawlerClient {
         }
 
         final boolean isSharedWorker = usingSharedWorker;
+        // Capture the same Page instance that execute() synchronizes on, before any teardown,
+        // so close() contends on that exact monitor instead of racing an in-flight execute().
+        final Page pageRef = worker.getValue4();
 
         if (logger.isDebugEnabled()) {
             logger.debug("Initiating Playwright worker cleanup (shared: {})", isSharedWorker);
         }
 
         try {
-            if (isSharedWorker) {
-                synchronized (INITIALIZATION_LOCK) {
-                    final int refCount = SHARED_WORKER_REF_COUNT.decrementAndGet();
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Shared worker reference count decremented to: {}", refCount);
-                    }
+            synchronized (pageRef) {
+                // Mark this instance closed before/alongside teardown so that any thread that is
+                // currently inside, or next enters, execute()'s synchronized(page) block on this
+                // same monitor observes it immediately.
+                closed = true;
 
-                    if (refCount <= 0) {
-                        if (logger.isInfoEnabled()) {
-                            logger.info("No more references to shared worker, closing resources");
-                        }
-                        close(worker.getValue1(), worker.getValue2(), worker.getValue3(), worker.getValue4());
-                        SHARED_WORKER = null;
-                        SHARED_WORKER_REF_COUNT.set(0);
-                    } else {
+                if (isSharedWorker) {
+                    synchronized (INITIALIZATION_LOCK) {
+                        final int refCount = SHARED_WORKER_REF_COUNT.decrementAndGet();
                         if (logger.isDebugEnabled()) {
-                            logger.debug("Shared worker still in use by {} other client(s), not closing", refCount);
+                            logger.debug("Shared worker reference count decremented to: {}", refCount);
+                        }
+
+                        if (refCount <= 0) {
+                            if (logger.isInfoEnabled()) {
+                                logger.info("No more references to shared worker, closing resources");
+                            }
+                            close(worker.getValue1(), worker.getValue2(), worker.getValue3(), worker.getValue4());
+                            SHARED_WORKER = null;
+                            SHARED_WORKER_REF_COUNT.set(0);
+                        } else {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Shared worker still in use by {} other client(s), not closing", refCount);
+                            }
                         }
                     }
+                } else {
+                    close(worker.getValue1(), worker.getValue2(), worker.getValue3(), worker.getValue4());
                 }
-            } else {
-                close(worker.getValue1(), worker.getValue2(), worker.getValue3(), worker.getValue4());
             }
         } finally {
             worker = null;
@@ -380,6 +405,10 @@ public class PlaywrightClient extends AbstractCrawlerClient {
 
     /**
      * Closes the Playwright worker in the background.
+     *
+     * <p>Note: if {@code closer} (e.g. {@code page.close()}) itself hangs past {@link #closeTimeout},
+     * this method gives up waiting and returns, but the abandoned daemon thread may still be running
+     * afterward. This is a pre-existing, separate limitation and is not addressed here.</p>
      *
      * @param closer The runnable to close the worker.
      */
@@ -493,6 +522,12 @@ public class PlaywrightClient extends AbstractCrawlerClient {
     @Override
     public ResponseData execute(final RequestData request) {
         if (worker == null) {
+            if (closed) {
+                // This instance was already closed and never re-init()'d since: reject immediately
+                // instead of silently resurrecting it via auto-init. (Calling init() explicitly again
+                // after close() is still supported and clears this flag - see init().)
+                throw new CrawlerSystemException("PlaywrightClient has already been closed. URL: " + request.getUrl());
+            }
             if (logger.isDebugEnabled()) {
                 logger.debug("Worker not initialized, triggering init()");
             }
@@ -513,6 +548,10 @@ public class PlaywrightClient extends AbstractCrawlerClient {
         final Consumer<Download> downloadHandler = download -> downloadRef.compareAndSet(null, download);
 
         synchronized (page) {
+            if (closed) {
+                throw new CrawlerSystemException("PlaywrightClient has already been closed. URL: " + url);
+            }
+
             if (logger.isDebugEnabled()) {
                 logger.debug("Acquired page lock for URL: {}", url);
             }
@@ -525,18 +564,44 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                     logger.debug("Download handler registered for potential file downloads");
                 }
 
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Accessing {}", url);
+                final Response response;
+                try {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Accessing {}", url);
+                    }
+                    response = page.navigate(url);
+                } catch (final Exception e) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Page navigation failed, attempting to handle as file download: {}", e.getMessage());
+                    }
+                    return waitForDownloadOrFail(page, request, responseRef, downloadRef, e);
                 }
-                final Response response = page.navigate(url);
 
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Waiting for LoadState: {}", renderedState);
-                }
-                page.waitForLoadState(renderedState);
+                try {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Waiting for LoadState: {}", renderedState);
+                    }
+                    page.waitForLoadState(renderedState);
 
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Page reached LoadState: {}", renderedState);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Page reached LoadState: {}", renderedState);
+                    }
+                } catch (final PlaywrightException e) {
+                    if (downloadRef.get() != null) {
+                        // A download may have started as a side effect even though the load-state wait
+                        // itself timed out (e.g. a JS-triggered download on a page that is also chatty).
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("waitForLoadState failed but a download was already detected, "
+                                    + "attempting to handle as file download: {}", e.getMessage());
+                        }
+                        return waitForDownloadOrFail(page, request, responseRef, downloadRef, e);
+                    }
+                    // No download fired: the page still navigated and rendered successfully, it just
+                    // never reached the configured LoadState (e.g. NETWORKIDLE never fires for pages
+                    // with persistent connections). Don't discard the successfully-loaded content.
+                    logger.warn(
+                            "Timed out waiting for LoadState '{}' on URL: {}. Falling back to the content " + "that was already loaded.",
+                            renderedState, url, e);
                 }
 
                 if (contentWaitDuration > 0L) {
@@ -550,50 +615,6 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                     logger.debug("Loaded: Base URL: {}, Response URL: {}", url, response.url());
                 }
                 return createResponseData(page, request, response, null);
-            } catch (final Exception e) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Page navigation failed, attempting to handle as file download: {}", e.getMessage());
-                }
-
-                // Wait for download with progressive backoff for responsiveness
-                // Start with short intervals, increase over time to balance responsiveness and CPU efficiency
-                // Note: page.waitForTimeout() is required to drive Playwright's event loop
-                final long timeoutMs = downloadTimeout * 1000L;
-                final long startTime = System.currentTimeMillis();
-                long pollInterval = 100L; // Start with 100ms
-                while (System.currentTimeMillis() - startTime < timeoutMs) {
-                    if (responseRef.get() != null && downloadRef.get() != null) {
-                        break;
-                    }
-                    try {
-                        page.waitForTimeout(pollInterval);
-                        // Progressive backoff: 100ms -> 200ms -> 400ms -> 500ms (max)
-                        if (pollInterval < 500L) {
-                            pollInterval = Math.min(pollInterval * 2, 500L);
-                        }
-                    } catch (final Exception ignored) {
-                        // ignore timeout exceptions during polling
-                    }
-                }
-                if (logger.isDebugEnabled()) {
-                    final long elapsed = System.currentTimeMillis() - startTime;
-                    logger.debug("Download wait completed after {}ms, timeout: {}s", elapsed, downloadTimeout);
-                }
-
-                final Response response = responseRef.get();
-                final Download download = downloadRef.get();
-                if (response != null && download != null) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Downloaded:  URL: {}", response.url());
-                    }
-                    return createResponseData(page, request, response, download);
-                }
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Failed to access URL - response: {}, download: {}", response != null, download != null);
-                }
-                final String errorDetails = "URL: " + request.getUrl() + ", Response received: " + (response != null)
-                        + ", Download started: " + (download != null) + ", Timeout: " + downloadTimeout + "s";
-                throw new CrawlingAccessException("Failed to access the URL. " + errorDetails, e);
             } finally {
                 // Clean up event handlers to prevent memory leaks
                 page.offResponse(responseHandler);
@@ -605,6 +626,67 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                 resetPage(page);
             }
         }
+    }
+
+    /**
+     * Waits for a download to be detected (via the {@code responseRef}/{@code downloadRef} handlers
+     * registered in {@link #execute(RequestData)}), or fails with a {@link CrawlingAccessException}
+     * if none is detected within {@link #downloadTimeout}.
+     *
+     * <p>This is used when the browser reports an in-page navigation failure that may actually be a
+     * file download (Chromium/Firefox/WebKit abort in-page navigation when the target triggers a
+     * download), or when a download was detected as a side effect of an otherwise-failed load-state
+     * wait.</p>
+     *
+     * @param page The page.
+     * @param request The request data.
+     * @param responseRef A reference populated by the page's {@code onResponse} handler, if any.
+     * @param downloadRef A reference populated by the page's {@code onDownload} handler, if any.
+     * @param cause The exception that triggered this fallback, used as the cause of the thrown
+     *            {@link CrawlingAccessException} if no download is detected.
+     * @return The response data for the detected download.
+     */
+    protected ResponseData waitForDownloadOrFail(final Page page, final RequestData request, final AtomicReference<Response> responseRef,
+            final AtomicReference<Download> downloadRef, final Exception cause) {
+        // Wait for download with progressive backoff for responsiveness
+        // Start with short intervals, increase over time to balance responsiveness and CPU efficiency
+        // Note: page.waitForTimeout() is required to drive Playwright's event loop
+        final long timeoutMs = downloadTimeout * 1000L;
+        final long startTime = System.currentTimeMillis();
+        long pollInterval = 100L; // Start with 100ms
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            if (responseRef.get() != null && downloadRef.get() != null) {
+                break;
+            }
+            try {
+                page.waitForTimeout(pollInterval);
+                // Progressive backoff: 100ms -> 200ms -> 400ms -> 500ms (max)
+                if (pollInterval < 500L) {
+                    pollInterval = Math.min(pollInterval * 2, 500L);
+                }
+            } catch (final Exception ignored) {
+                // ignore timeout exceptions during polling
+            }
+        }
+        if (logger.isDebugEnabled()) {
+            final long elapsed = System.currentTimeMillis() - startTime;
+            logger.debug("Download wait completed after {}ms, timeout: {}s", elapsed, downloadTimeout);
+        }
+
+        final Response response = responseRef.get();
+        final Download download = downloadRef.get();
+        if (response != null && download != null) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Downloaded:  URL: {}", response.url());
+            }
+            return createResponseData(page, request, response, download);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Failed to access URL - response: {}, download: {}", response != null, download != null);
+        }
+        final String errorDetails = "URL: " + request.getUrl() + ", Response received: " + (response != null) + ", Download started: "
+                + (download != null) + ", Timeout: " + downloadTimeout + "s";
+        throw new CrawlingAccessException("Failed to access the URL. " + errorDetails, cause);
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientConcurrencyTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientConcurrencyTest.java
@@ -720,4 +720,115 @@ public class PlaywrightClientConcurrencyTest extends PlainTestCase {
             slowServer.stop();
         }
     }
+
+    // ==================== lock-ordering / deadlock regression tests ====================
+
+    /**
+     * Regression backstop for the lock-ordering invariant documented on
+     * {@code PlaywrightClient.INITIALIZATION_LOCK} (a {@code Page} monitor must always be acquired
+     * before {@code INITIALIZATION_LOCK}, never the reverse).
+     *
+     * <p>This does NOT prove deadlock-freedom by itself - that's established by the lock-ordering
+     * argument (only {@code close()} ever nests both locks, always in the same order). What this test
+     * gives is an executable guardrail: it hammers {@code init()}/{@code execute()}/{@code close()}
+     * concurrently across several client instances - some sharing one worker/{@code Page} (so their
+     * {@code close()}/{@code execute()} calls genuinely contend on the same monitor) and some
+     * independent (so their {@code init()}/{@code close()} calls only ever contend via the static
+     * {@code INITIALIZATION_LOCK}) - so that if a future change ever introduces a reverse-order lock
+     * acquisition, this test hangs instead of passing silently.</p>
+     *
+     * <p>Each client instance is driven by exactly one dedicated thread (never two threads calling
+     * {@code close()} on the very same instance), so this deliberately does not exercise the
+     * unrelated, pre-existing, low-severity close()-vs-close() TOCTOU race on a single instance - only
+     * the cross-instance/cross-lock interactions relevant to the deadlock question.</p>
+     *
+     * <p>The bounded wait below uses {@code Future#get(timeout)} on a daemon-thread executor rather
+     * than relying on {@code @Timeout} to interrupt hung worker threads: a thread blocked entering a
+     * {@code synchronized} block is not interruptible, so if a real deadlock were ever reintroduced,
+     * {@code @Timeout} alone could not unblock it. This way the test still fails cleanly (via
+     * {@code TimeoutException}) and the daemon threads cannot prevent the JVM/build from exiting.</p>
+     */
+    @Test
+    @Timeout(90)
+    public void test_concurrentInitExecuteClose_mixedSharedAndNonShared_noDeadlock() throws Exception {
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final Map<String, Object> sharedParamMap = new HashMap<>();
+        sharedParamMap.put("sharedClient", Boolean.TRUE);
+
+        final List<PlaywrightClient> clients = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            final PlaywrightClient client = new PlaywrightClient() {
+                @Override
+                protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                    return Optional.ofNullable(mimeTypeHelper);
+                }
+            };
+            client.setInitParameterMap(sharedParamMap);
+            client.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            client.setCloseTimeout(5);
+            clients.add(client);
+        }
+        for (int i = 0; i < 2; i++) {
+            final PlaywrightClient client = new PlaywrightClient() {
+                @Override
+                protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                    return Optional.ofNullable(mimeTypeHelper);
+                }
+            };
+            client.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            client.setCloseTimeout(5);
+            clients.add(client);
+        }
+
+        final ExecutorService executor = Executors.newFixedThreadPool(clients.size(), r -> {
+            final Thread thread = new Thread(r, "deadlock-stress");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        try {
+            final String url = "http://[::1]:" + SERVER_PORT + "/";
+            final int iterationsPerThread = 10;
+            final AtomicInteger unexpectedErrors = new AtomicInteger(0);
+            final List<Future<?>> futures = new ArrayList<>();
+
+            for (final PlaywrightClient client : clients) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        for (int iter = 0; iter < iterationsPerThread; iter++) {
+                            client.init();
+                            final ResponseData responseData = client.execute(RequestDataBuilder.newRequestData().get().url(url).build());
+                            if (responseData.getHttpStatusCode() != 200) {
+                                unexpectedErrors.incrementAndGet();
+                            }
+                            if (iter % 3 == 2) {
+                                // Exercise this instance's own close()-then-reinit cycle while OTHER
+                                // threads are concurrently doing the same on their own instances -
+                                // for the shared instances this contends on the same Page monitor.
+                                client.close();
+                                client.init();
+                            }
+                        }
+                    } catch (final Exception e) {
+                        unexpectedErrors.incrementAndGet();
+                    }
+                }));
+            }
+
+            for (final Future<?> future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+
+            assertEquals(0, unexpectedErrors.get());
+        } finally {
+            executor.shutdownNow();
+            for (final PlaywrightClient client : clients) {
+                try {
+                    client.close();
+                } catch (final Exception e) {
+                    // ignore - best-effort cleanup
+                }
+            }
+        }
+    }
 }

--- a/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientConcurrencyTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientConcurrencyTest.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.crawler.client.http;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,14 +32,24 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.codelibs.core.io.ResourceUtil;
 import org.codelibs.fess.crawler.builder.RequestDataBuilder;
 import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.helper.MimeTypeHelper;
 import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
 import org.codelibs.fess.crawler.util.CrawlerWebServer;
 import org.dbflute.utflute.core.PlainTestCase;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
 
 import com.microsoft.playwright.BrowserType;
 
@@ -602,6 +613,111 @@ public class PlaywrightClientConcurrencyTest extends PlainTestCase {
             assertEquals(numRequests, successCount);
         } finally {
             playwrightClient.close();
+        }
+    }
+
+    // ==================== close()-vs-execute() race tests ====================
+
+    /**
+     * Test that close() called concurrently with an in-flight execute() does not race:
+     * close() must wait for the in-flight request to release the page's monitor before tearing
+     * down Playwright resources, rather than closing the page/context/browser out from under it.
+     */
+    @Test
+    @Timeout(30)
+    public void test_close_duringInFlightExecute_waitsThenClosesSafely() throws Exception {
+        final int slowServerPort = 7151;
+        final Server slowServer = new Server();
+        final ServerConnector connector = new ServerConnector(slowServer);
+        connector.setPort(slowServerPort);
+        slowServer.addConnector(connector);
+        slowServer.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
+                // Sleep before responding so the corresponding execute() call is genuinely
+                // in-flight (blocked inside page.navigate()) when close() is invoked below.
+                Thread.sleep(1500L);
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/html;charset=UTF-8");
+                Content.Sink.write(response, true, "<html><body>slow page</body></html>", callback);
+                return true;
+            }
+        });
+        slowServer.start();
+
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final PlaywrightClient playwrightClient = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+        };
+        final ExecutorService executor = Executors.newFixedThreadPool(1);
+
+        try {
+            playwrightClient.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            playwrightClient.setCloseTimeout(5);
+            playwrightClient.init();
+
+            final String slowUrl = "http://[::1]:" + slowServerPort + "/";
+            final CountDownLatch execStarted = new CountDownLatch(1);
+            final AtomicReference<ResponseData> execResult = new AtomicReference<>();
+            final AtomicInteger closedDuringExec = new AtomicInteger(0);
+            final AtomicReference<Exception> unexpectedError = new AtomicReference<>();
+
+            final Future<?> execFuture = executor.submit(() -> {
+                execStarted.countDown();
+                try {
+                    execResult.set(playwrightClient.execute(RequestDataBuilder.newRequestData().get().url(slowUrl).build()));
+                } catch (final CrawlerSystemException e) {
+                    if (e.getMessage() != null && e.getMessage().contains("already been closed")) {
+                        // Also an acceptable, clean outcome: close() won the race for the monitor
+                        // and this execute() correctly observed closed==true before touching the page.
+                        closedDuringExec.incrementAndGet();
+                    } else {
+                        unexpectedError.set(e);
+                    }
+                } catch (final Exception e) {
+                    unexpectedError.set(e);
+                }
+            });
+
+            // Give the background thread time to actually enter execute()'s synchronized(page)
+            // block and start navigating the slow page before we call close() from this thread.
+            assertTrue(execStarted.await(10, TimeUnit.SECONDS));
+            Thread.sleep(300L);
+
+            // With the fix, close() must block until the in-flight execute() releases the page's
+            // monitor (rather than tearing down the page/context/browser concurrently), and then
+            // complete cleanly - all within this test's @Timeout bound.
+            playwrightClient.close();
+
+            execFuture.get(15, TimeUnit.SECONDS);
+
+            // (a) No crash / unexpected exception from the in-flight execute() call: either it
+            // completed successfully, or it cleanly observed the already-closed state.
+            assertNull(unexpectedError.get());
+            assertTrue(execResult.get() != null || closedDuringExec.get() > 0);
+            if (execResult.get() != null) {
+                assertEquals(200, execResult.get().getHttpStatusCode());
+            }
+
+            // (b) After close() returns, a subsequent execute() call on this instance must throw
+            // promptly with a clear message, proving the closed check works.
+            try {
+                playwrightClient.execute(RequestDataBuilder.newRequestData().get().url(slowUrl).build());
+                fail();
+            } catch (final CrawlerSystemException e) {
+                assertTrue(e.getMessage().contains("already been closed"));
+            }
+        } finally {
+            executor.shutdownNow();
+            try {
+                playwrightClient.close();
+            } catch (final Exception e) {
+                // ignore - best-effort cleanup
+            }
+            slowServer.stop();
         }
     }
 }

--- a/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientEdgeCaseTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientEdgeCaseTest.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.crawler.client.http;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
@@ -27,6 +28,7 @@ import java.util.Optional;
 import org.codelibs.core.exception.UnsupportedEncodingRuntimeException;
 import org.codelibs.core.io.InputStreamUtil;
 import org.codelibs.core.io.ResourceUtil;
+import org.codelibs.core.misc.Tuple4;
 import org.codelibs.fess.crawler.builder.RequestDataBuilder;
 import org.codelibs.fess.crawler.entity.ResponseData;
 import org.codelibs.fess.crawler.exception.CrawlingAccessException;
@@ -34,8 +36,20 @@ import org.codelibs.fess.crawler.helper.MimeTypeHelper;
 import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
 import org.codelibs.fess.crawler.util.CrawlerWebServer;
 import org.dbflute.utflute.core.PlainTestCase;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
 
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
 
 /**
  * Test class for PlaywrightClient edge cases and error handling.
@@ -356,6 +370,83 @@ public class PlaywrightClientEdgeCaseTest extends PlainTestCase {
         // Verify lastModified is set if available
         if (responseData.getLastModified() != null) {
             assertTrue(responseData.getLastModified().getTime() > 0);
+        }
+    }
+
+    // ==================== LoadState timeout handling tests ====================
+
+    /**
+     * Test that a page which loads successfully but never reaches the configured LoadState
+     * (e.g. NETWORKIDLE never firing because of a lingering same-origin network request) still
+     * returns the successfully-loaded content instead of being misclassified as a failed/absent
+     * download and discarded via CrawlingAccessException.
+     */
+    @Test
+    @Timeout(30)
+    public void test_execute_neverReachesLoadState_returnsLoadedContent() throws Exception {
+        final int neverIdlePort = 7091;
+        final Server neverIdleServer = new Server();
+        final ServerConnector connector = new ServerConnector(neverIdleServer);
+        connector.setPort(neverIdlePort);
+        neverIdleServer.addConnector(connector);
+        neverIdleServer.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
+                final String path = request.getHttpURI().getPath();
+                if ("/hang".equals(path)) {
+                    // Bounded "hang": long enough to outlast the short page timeout configured
+                    // below, short enough that server.stop() never has to wait for long.
+                    Thread.sleep(2000L);
+                    response.setStatus(200);
+                    response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain;charset=UTF-8");
+                    Content.Sink.write(response, true, "done", callback);
+                    return true;
+                }
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/html;charset=UTF-8");
+                // A same-origin fetch() (unlike an <img>/<script src>) is invisible to the page's
+                // "load" event, so navigate() itself returns promptly; but the pending connection
+                // keeps the network non-idle, so waitForLoadState(NETWORKIDLE) never succeeds.
+                Content.Sink.write(response, true,
+                        "<html><body>Never Idle Page<script>fetch('/hang').catch(function(e){});</script></body></html>", callback);
+                return true;
+            }
+        });
+        neverIdleServer.start();
+
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final PlaywrightClient neverIdleClient = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+
+            @Override
+            protected Tuple4<Playwright, Browser, BrowserContext, Page> createPlaywrightWorker() {
+                final Tuple4<Playwright, Browser, BrowserContext, Page> tuple = super.createPlaywrightWorker();
+                // Test-only: shorten the default timeout so waitForLoadState(NETWORKIDLE) times out
+                // in ~0.5s instead of Playwright's real default (~30s), without adding a production
+                // configuration knob. navigate() itself easily completes well under this on localhost.
+                tuple.getValue4().setDefaultTimeout(500);
+                return tuple;
+            }
+        };
+
+        try {
+            neverIdleClient.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            neverIdleClient.setCloseTimeout(5);
+            neverIdleClient.init();
+
+            final String url = "http://[::1]:" + neverIdlePort + "/";
+            final ResponseData responseData = neverIdleClient.execute(RequestDataBuilder.newRequestData().get().url(url).build());
+
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertEquals("text/html", responseData.getMimeType());
+            assertNotNull(responseData.getResponseBody());
+            assertTrue(getBodyAsString(responseData).contains("Never Idle Page"));
+        } finally {
+            neverIdleClient.close();
+            neverIdleServer.stop();
         }
     }
 

--- a/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientEdgeCaseTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientEdgeCaseTest.java
@@ -50,6 +50,8 @@ import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.PlaywrightException;
+import com.microsoft.playwright.options.LoadState;
 
 /**
  * Test class for PlaywrightClient edge cases and error handling.
@@ -447,6 +449,50 @@ public class PlaywrightClientEdgeCaseTest extends PlainTestCase {
         } finally {
             neverIdleClient.close();
             neverIdleServer.stop();
+        }
+    }
+
+    /**
+     * Test that a non-timeout {@link PlaywrightException} thrown while waiting for LoadState (e.g. the
+     * page/browser having crashed or been closed mid-wait) is NOT swallowed as "just a LoadState
+     * timeout, content is fine" the way a genuine {@link com.microsoft.playwright.TimeoutError} is. It
+     * must propagate as a real failure instead of returning fabricated "successfully loaded" content
+     * built from a page that is no longer in a trustworthy state.
+     */
+    @Test
+    @Timeout(30)
+    public void test_execute_nonTimeoutPlaywrightExceptionDuringLoadState_propagates() throws Exception {
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final PlaywrightClient crashingClient = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+
+            @Override
+            protected void waitForLoadState(final Page page, final LoadState state) {
+                // Simulate a non-timeout PlaywrightException (e.g. Playwright's own
+                // "Target page, context or browser has been closed") firing during the LoadState
+                // wait, after navigate() itself already succeeded.
+                throw new PlaywrightException("Target page, context or browser has been closed");
+            }
+        };
+
+        try {
+            crashingClient.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            crashingClient.setCloseTimeout(5);
+            crashingClient.init();
+
+            final String url = "http://[::1]:" + SERVER_PORT + "/";
+            try {
+                crashingClient.execute(RequestDataBuilder.newRequestData().get().url(url).build());
+                // Expected the PlaywrightException to propagate instead of being treated as a LoadState timeout
+                fail();
+            } catch (final PlaywrightException e) {
+                assertTrue(e.getMessage().contains("Target page, context or browser has been closed"));
+            }
+        } finally {
+            crashingClient.close();
         }
     }
 

--- a/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientEdgeCaseTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientEdgeCaseTest.java
@@ -51,6 +51,7 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import com.microsoft.playwright.PlaywrightException;
+import com.microsoft.playwright.TimeoutError;
 import com.microsoft.playwright.options.LoadState;
 
 /**
@@ -494,6 +495,155 @@ public class PlaywrightClientEdgeCaseTest extends PlainTestCase {
         } finally {
             crashingClient.close();
         }
+    }
+
+    /**
+     * Test the grace-poll fix: when the LoadState wait times out with NO download detected yet at
+     * that instant, but a download fires shortly afterwards (within the short grace window), the
+     * download must be detected and handled as a file download instead of the already-loaded HTML
+     * being served. Before the fix, execute() fell straight through to returning the loaded HTML the
+     * moment the timeout was observed, silently missing the download.
+     */
+    @Test
+    @Timeout(30)
+    public void test_execute_loadStateTimeout_lateDownloadWithinGracePeriod_handledAsDownload() throws Exception {
+        final int port = 7092;
+        final Server server = newTwoEndpointServer(port, "GRACE-HTML-PAGE", "GRACE-POLL-DOWNLOAD-BODY");
+        server.start();
+
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final PlaywrightClient client = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+
+            @Override
+            protected void waitForLoadState(final Page page, final LoadState state) {
+                // Schedule a download to fire shortly (well within the grace window) but AFTER this
+                // method throws. No Playwright call runs between evaluate() returning and the throw,
+                // so the download event cannot be delivered until execute()'s grace-poll pumps the
+                // event loop - guaranteeing downloadRef is still null at the instant of the timeout,
+                // and therefore that the grace-poll branch (not the already-detected branch) is
+                // exercised.
+                // Fire the download via a same-origin <a download> click deferred to the next event-
+                // loop tick (setTimeout 0). Deferring guarantees the download event cannot be delivered
+                // to the Java handler until execute()'s grace-poll pumps the loop - so downloadRef is
+                // still null at the instant of the timeout and the grace-poll branch (not the already-
+                // detected branch) is exercised. An <a download> click (rather than a top-level
+                // navigation to the download URL) fires the download promptly and reliably.
+                page.evaluate("setTimeout(() => { const a = document.createElement('a'); a.href = '/download.bin';"
+                        + " a.download = 'download.bin'; document.body.appendChild(a); a.click(); }, 0)");
+                throw new TimeoutError("simulated LoadState timeout with a download arriving shortly after");
+            }
+        };
+
+        try {
+            client.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            client.setDownloadTimeout(5);
+            client.setCloseTimeout(5);
+            client.init();
+
+            final String url = "http://[::1]:" + port + "/";
+            final ResponseData responseData = client.execute(RequestDataBuilder.newRequestData().get().url(url).build());
+
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertTrue(responseData.getContentLength() > 0);
+            final String body = getBodyAsString(responseData);
+            // The late download was caught and its body served ...
+            assertTrue(body.contains("GRACE-POLL-DOWNLOAD-BODY"));
+            // ... instead of the already-loaded HTML page content.
+            assertFalse(body.contains("GRACE-HTML-PAGE"));
+        } finally {
+            client.close();
+            server.stop();
+        }
+    }
+
+    /**
+     * Test the preserved already-detected branch: when the LoadState wait times out AND a download
+     * has ALREADY been detected (downloadRef is non-null) at the instant of the timeout, the request
+     * is routed to the download-handling path. This branch had no dedicated test before.
+     */
+    @Test
+    @Timeout(30)
+    public void test_execute_loadStateTimeout_downloadAlreadyDetected_handledAsDownload() throws Exception {
+        final int port = 7093;
+        final Server server = newTwoEndpointServer(port, "DETECTED-HTML-PAGE", "ALREADY-DETECTED-DOWNLOAD-BODY");
+        server.start();
+
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final PlaywrightClient client = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+
+            @Override
+            protected void waitForLoadState(final Page page, final LoadState state) {
+                // Trigger a download (via a reliable same-origin <a download> click) and block until it
+                // is observed, so the page's onDownload handler (registered in execute() before this
+                // call) has already populated downloadRef by the time the simulated LoadState timeout is
+                // thrown - exercising the already-detected branch rather than the grace-poll branch.
+                page.waitForDownload(() -> page.evaluate("(() => { const a = document.createElement('a');"
+                        + " a.href = '/download.bin'; a.download = 'download.bin'; document.body.appendChild(a); a.click(); })()"));
+                throw new TimeoutError("simulated LoadState timeout with a download already in progress");
+            }
+        };
+
+        try {
+            client.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            client.setDownloadTimeout(5);
+            client.setCloseTimeout(5);
+            client.init();
+
+            final String url = "http://[::1]:" + port + "/";
+            final ResponseData responseData = client.execute(RequestDataBuilder.newRequestData().get().url(url).build());
+
+            assertEquals(200, responseData.getHttpStatusCode());
+            assertTrue(responseData.getContentLength() > 0);
+            final String body = getBodyAsString(responseData);
+            assertTrue(body.contains("ALREADY-DETECTED-DOWNLOAD-BODY"));
+            assertFalse(body.contains("DETECTED-HTML-PAGE"));
+        } finally {
+            client.close();
+            server.stop();
+        }
+    }
+
+    /**
+     * Builds a Jetty server exposing two endpoints on {@code port}: {@code /download.bin} returns a
+     * non-renderable {@code application/octet-stream} body (which chromium turns into a download) and
+     * any other path returns a small HTML page. The two distinct marker strings let a test tell which
+     * of the two was ultimately served in the response body.
+     *
+     * @param port The port to listen on.
+     * @param htmlMarker A marker string embedded in the HTML page body.
+     * @param downloadMarker The exact body returned for {@code /download.bin}.
+     * @return An unstarted {@link Server}; the caller must {@code start()} and {@code stop()} it.
+     */
+    private Server newTwoEndpointServer(final int port, final String htmlMarker, final String downloadMarker) {
+        final Server server = new Server();
+        final ServerConnector connector = new ServerConnector(server);
+        connector.setPort(port);
+        server.addConnector(connector);
+        server.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
+                final String path = request.getHttpURI().getPath();
+                if ("/download.bin".equals(path)) {
+                    response.setStatus(200);
+                    response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/octet-stream");
+                    Content.Sink.write(response, true, downloadMarker, callback);
+                    return true;
+                }
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/html;charset=UTF-8");
+                Content.Sink.write(response, true, "<html><body>" + htmlMarker + "</body></html>", callback);
+                return true;
+            }
+        });
+        return server;
     }
 
     private String getBodyAsString(final ResponseData responseData) {

--- a/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientExceptionTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientExceptionTest.java
@@ -18,19 +18,32 @@ package org.codelibs.fess.crawler.client.http;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.util.Optional;
 
 import org.codelibs.core.io.ResourceUtil;
+import org.codelibs.fess.crawler.CrawlerContext;
 import org.codelibs.fess.crawler.builder.RequestDataBuilder;
 import org.codelibs.fess.crawler.entity.ResponseData;
+import org.codelibs.fess.crawler.exception.ChildUrlsException;
 import org.codelibs.fess.crawler.exception.CrawlerSystemException;
 import org.codelibs.fess.crawler.exception.CrawlingAccessException;
+import org.codelibs.fess.crawler.filter.UrlFilter;
 import org.codelibs.fess.crawler.helper.MimeTypeHelper;
 import org.codelibs.fess.crawler.helper.impl.MimeTypeHelperImpl;
 import org.codelibs.fess.crawler.util.CrawlerWebServer;
+import org.codelibs.fess.crawler.util.CrawlingParameterUtil;
 import org.dbflute.utflute.core.PlainTestCase;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
 
 import com.microsoft.playwright.BrowserType;
 
@@ -490,6 +503,107 @@ public class PlaywrightClientExceptionTest extends PlainTestCase {
             assertTrue(e.getMessage().contains("Timeout"));
         } finally {
             playwrightClient.close();
+        }
+    }
+
+    // ==================== ChildUrlsException propagation tests ====================
+
+    /**
+     * Test that a {@link ChildUrlsException} thrown from {@code createResponseData()} (when a redirect
+     * lands on a URL the {@link UrlFilter} rejects as a non-target) PROPAGATES out of {@code execute()}
+     * rather than being swallowed. Before the PR restructured {@code execute()}, that
+     * {@code createResponseData()} call sat inside a broad {@code catch (Exception)} that turned any
+     * such {@code ChildUrlsException} into a download-wait and ultimately a {@link CrawlingAccessException},
+     * hiding the framework's intended child-URL signal.
+     */
+    @Test
+    @Timeout(30)
+    public void test_execute_redirectToNonTargetUrl_childUrlsExceptionPropagates() throws Exception {
+        final int port = 7201;
+        final Server server = new Server();
+        final ServerConnector connector = new ServerConnector(server);
+        connector.setPort(port);
+        server.addConnector(connector);
+        server.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(final Request request, final Response response, final Callback callback) throws Exception {
+                final String path = request.getHttpURI().getPath();
+                if ("/redirect".equals(path)) {
+                    // Redirect to a different path so response.url() differs from the requested URL,
+                    // which is what makes execute() consult the UrlFilter.
+                    response.setStatus(302);
+                    response.getHeaders().put(HttpHeader.LOCATION, "/final.html");
+                    Content.Sink.write(response, true, "", callback);
+                    return true;
+                }
+                response.setStatus(200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/html;charset=UTF-8");
+                Content.Sink.write(response, true, "<html><body>final page</body></html>", callback);
+                return true;
+            }
+        });
+        server.start();
+
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final PlaywrightClient client = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+        };
+
+        // A UrlFilter that rejects every URL: match() is only consulted for the post-redirect URL, so
+        // returning false forces the "redirected to a non-target URL" ChildUrlsException path.
+        final CrawlerContext crawlerContext = new CrawlerContext();
+        crawlerContext.setUrlFilter(new UrlFilter() {
+            @Override
+            public void init(final String sessionId) {
+            }
+
+            @Override
+            public boolean match(final String url) {
+                return false;
+            }
+
+            @Override
+            public void addInclude(final String urlPattern) {
+            }
+
+            @Override
+            public void addExclude(final String urlPattern) {
+            }
+
+            @Override
+            public void processUrl(final String url) {
+            }
+
+            @Override
+            public void clear() {
+            }
+        });
+
+        try {
+            client.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            client.setDownloadTimeout(5);
+            client.setCloseTimeout(5);
+            client.init();
+
+            CrawlingParameterUtil.setCrawlerContext(crawlerContext);
+
+            final String url = "http://[::1]:" + port + "/redirect";
+            try {
+                client.execute(RequestDataBuilder.newRequestData().get().url(url).build());
+                fail();
+            } catch (final ChildUrlsException e) {
+                // Expected: the child-URL signal propagates out of execute() unchanged.
+            } catch (final CrawlingAccessException e) {
+                // ChildUrlsException must NOT be swallowed into CrawlingAccessException (the pre-fix bug).
+                fail();
+            }
+        } finally {
+            CrawlingParameterUtil.setCrawlerContext(null);
+            client.close();
+            server.stop();
         }
     }
 }


### PR DESCRIPTION
## Summary
- `close()` now acquires the same `Page` monitor `execute()` uses before tearing down the Playwright page/context/browser, fixing a race where a concurrent `close()` (e.g. a crawl force-stop) could destroy resources while a request was still in flight. A closed instance now rejects further `execute()` calls with a clear error.
- `execute()` no longer treats a `waitForLoadState()` timeout (the default `NETWORKIDLE` state never fires on pages with persistent connections, e.g. websockets/long-polling/analytics) as a possible file download. If navigation itself succeeded, the already-loaded content is now returned instead of discarding the page via `CrawlingAccessException`.

## Test plan
- [x] Added `PlaywrightClientConcurrencyTest#test_close_duringInFlightExecute_waitsThenClosesSafely`
- [x] Added `PlaywrightClientEdgeCaseTest#test_execute_neverReachesLoadState_returnsLoadedContent` — verified it fails against the pre-fix code and passes after the fix
- [x] Full suite: `mvn test` — 188/188 passing, no regressions