### PR TITLE
docs: document that close() waits on in-flight execute() timeouts

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
+++ b/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
@@ -378,6 +378,18 @@ public class PlaywrightClient extends AbstractCrawlerClient {
         return new Tuple4<>(playwright, browser, browserContext, page);
     }
 
+    /**
+     * Closes the Playwright worker held by this instance (or decrements the shared-worker
+     * reference count and closes the shared worker once no client references remain).
+     *
+     * <p>This method synchronizes on the same {@code Page} monitor as {@link #execute(RequestData)},
+     * so it blocks until any in-flight {@code execute()} on this instance's page has finished before
+     * tearing resources down. That wait has no timeout of its own; it is bounded only by whatever
+     * navigation, load-state, content-wait and download timeouts are effectively in force for the
+     * in-flight request (Playwright's own defaults, or the values set via {@link #downloadTimeout},
+     * {@link #contentWaitDuration} and the related setters), so configuring those to very long or
+     * effectively unlimited values lets a single slow request delay {@code close()} for just as long.</p>
+     */
     @Override
     public void close() {
         if (worker == null) {


### PR DESCRIPTION
## Summary
- Follow-up from #50's review: `close()` now synchronizes on the same `Page` monitor as `execute()`, correctly waiting for any in-flight request to finish before tearing down Playwright resources. That wait has no timeout of its own, and is bounded only by whatever navigation/load-state/content-wait/download timeouts are effectively configured for the in-flight request. This was an intentional design tradeoff (not a bug), but undocumented — this PR adds a Javadoc note on `close()` explaining the bound so future maintainers and users who configure very long or unlimited timeouts understand the consequence for `close()` latency.
- Documentation-only change; no behavior/logic modified.

## Test plan
- [x] `mvn test` — 193/193 passing, unchanged from main (no logic touched)
- [x] `mvn javadoc:jar` — passes (this repo's CI fails on javadoc errors; verified the new Javadoc block doesn't introduce any unresolved `{@link}` references)