### PR TITLE
fix: surface navigate() null response as a clean CrawlingAccessException

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
+++ b/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
@@ -615,12 +615,22 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Accessing {}", url);
                     }
-                    response = page.navigate(url);
+                    response = navigate(page, url);
                 } catch (final Exception e) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Page navigation failed, attempting to handle as file download: {}", e.getMessage());
                     }
                     return waitForDownloadOrFail(page, request, responseRef, downloadRef, e);
+                }
+
+                // Playwright's navigate() legitimately returns null for some same-document navigations
+                // (e.g. a hash-fragment-only change). Everything downstream (the debug log below and
+                // createResponseData) dereferences this response, so surface a clean, catchable failure
+                // here instead of letting it propagate as a raw NullPointerException. Must stay OUTSIDE
+                // the catch above: CrawlingAccessException is a RuntimeException, so throwing it inside
+                // that try would be swallowed and misrouted to the download fallback.
+                if (response == null) {
+                    throw new CrawlingAccessException("Failed to access the URL. Navigation returned no response. URL: " + url);
                 }
 
                 try {
@@ -692,6 +702,22 @@ public class PlaywrightClient extends AbstractCrawlerClient {
                 resetPage(page);
             }
         }
+    }
+
+    /**
+     * Navigates the page to the given URL and returns the main-resource response.
+     *
+     * <p>Extracted as its own protected method (rather than calling {@link Page#navigate(String)}
+     * directly from {@link #execute(RequestData)}) purely as a test seam, so tests can simulate a
+     * {@code null} response - which Playwright's API permits for some same-document navigations - without
+     * needing a real page that performs such a navigation.</p>
+     *
+     * @param page The page.
+     * @param url The URL to navigate to.
+     * @return The main-resource response, or {@code null} for a same-document navigation.
+     */
+    protected Response navigate(final Page page, final String url) {
+        return page.navigate(url);
     }
 
     /**

--- a/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientEdgeCaseTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientEdgeCaseTest.java
@@ -498,6 +498,54 @@ public class PlaywrightClientEdgeCaseTest extends PlainTestCase {
     }
 
     /**
+     * Test that when {@link Page#navigate(String)} returns {@code null} - which Playwright's API permits
+     * for some same-document navigations (e.g. a hash-fragment-only change) - execute() surfaces a clean,
+     * catchable {@link CrawlingAccessException} naming the URL, instead of letting a raw
+     * {@link NullPointerException} propagate out of the response dereference downstream.
+     */
+    @Test
+    @Timeout(30)
+    public void test_execute_navigateReturnsNull_throwsCrawlingAccessException() {
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final PlaywrightClient nullNavigateClient = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+
+            @Override
+            protected com.microsoft.playwright.Response navigate(final Page page, final String url) {
+                // Simulate Playwright returning no main-resource response (a same-document navigation).
+                return null;
+            }
+        };
+
+        try {
+            nullNavigateClient.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            // Short download timeout: were the null-guard misplaced inside the navigate try/catch, the
+            // throw would be swallowed and rerouted to the download fallback, which would poll for this
+            // long before failing - so a wrong placement fails fast (and with a different message) here.
+            nullNavigateClient.setDownloadTimeout(3);
+            nullNavigateClient.setCloseTimeout(5);
+            nullNavigateClient.init();
+
+            final String url = "http://[::1]:" + SERVER_PORT + "/";
+            try {
+                nullNavigateClient.execute(RequestDataBuilder.newRequestData().get().url(url).build());
+                fail();
+            } catch (final CrawlingAccessException e) {
+                // Assert on the distinctive fragment (not merely "Failed to access", which the
+                // download-fallback path also emits) so this proves the navigate()-returned-null guard
+                // specifically, plus that the offending URL is included.
+                assertTrue(e.getMessage().contains("Navigation returned no response"));
+                assertTrue(e.getMessage().contains(url));
+            }
+        } finally {
+            nullNavigateClient.close();
+        }
+    }
+
+    /**
      * Test the grace-poll fix: when the LoadState wait times out with NO download detected yet at
      * that instant, but a download fires shortly afterwards (within the short grace window), the
      * download must be detected and handled as a file download instead of the already-loaded HTML


### PR DESCRIPTION
## Summary
- Follow-up from #50's review: `page.navigate()` can legitimately return `null` for some same-document navigations (e.g. a hash-fragment-only change). Downstream code (a debug log and `createResponseData()`) dereferenced the response unconditionally, so a `null` return surfaced as a raw `NullPointerException` instead of a clean, catchable crawler failure.
- Added a guard immediately after navigation (outside the existing navigate() try/catch, so it isn't misrouted into the download-fallback path) that throws `CrawlingAccessException` naming the URL, matching this file's existing "Failed to access the URL..." convention.
- Extracted `navigate(Page, String)` as a small protected seam (mirroring the existing `waitForLoadState()` seam from #50) purely so this can be tested without needing a real same-document navigation.

## Test plan
- [x] Added `PlaywrightClientEdgeCaseTest#test_execute_navigateReturnsNull_throwsCrawlingAccessException` — simulates a null navigate() response and asserts `CrawlingAccessException` (not NPE) with a message naming the failure and the URL
- [x] `mvn test` — 194/194 passing (full suite + new test)
- [x] `mvn javadoc:jar` — passes (CI javadoc gate)