### PR TITLE
fix: make close() idempotent against concurrent double-close

### DIFF
--- a/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
+++ b/src/main/java/org/codelibs/fess/crawler/client/http/PlaywrightClient.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -239,6 +240,25 @@ public class PlaywrightClient extends AbstractCrawlerClient {
     private volatile boolean closed = false;
 
     /**
+     * Idempotency latch for {@link #close()}: atomically flipped from {@code false} to {@code true} by
+     * the first thread that enters {@code close()}, as that method's very first action - before it
+     * touches {@link #worker}, any {@code Page} monitor, or {@link #INITIALIZATION_LOCK}.
+     *
+     * <p>Guards against a concurrent {@code close()}-vs-{@code close()} race on a single instance: if
+     * two threads call {@code close()} simultaneously, both could otherwise pass the plain
+     * {@code worker == null} check before either nulled the field and each decrement
+     * {@link #SHARED_WORKER_REF_COUNT}, driving a still-in-use shared worker's refcount to zero
+     * prematurely (and/or NPE-ing on the second thread's now-nulled {@code worker}). The loser of the
+     * {@code compareAndSet(false, true)} returns immediately as a no-op - it must NOT block on the
+     * winner (which already tears down exactly once, single-threaded, and correctly waits for in-flight
+     * {@code execute()} calls) nor touch any resource. Reset to {@code false} by {@link #init()}
+     * alongside {@link #closed}, so a re-init()'d instance can be closed again (the normal
+     * single-owner-thread lifecycle). This is a defense-in-depth guard for API misuse; the supported
+     * pattern is one owner thread per instance.
+     */
+    private final AtomicBoolean closeInvoked = new AtomicBoolean(false);
+
+    /**
      * The crawler container instance.
      */
     @Resource
@@ -314,6 +334,10 @@ public class PlaywrightClient extends AbstractCrawlerClient {
             // surfaces as this class's own "already closed" CrawlerSystemException rather than a raw
             // NullPointerException.
             closed = false;
+            // Re-arm the close() idempotency latch so this freshly (re-)initialized instance can be
+            // closed again. Symmetric with `closed` above; without it a close()-then-init() cycle would
+            // leave the latch set and the next close() would silently no-op (leaking the shared worker).
+            closeInvoked.set(false);
 
             if (logger.isDebugEnabled()) {
                 logger.debug("Playwright initialization completed successfully");
@@ -380,6 +404,19 @@ public class PlaywrightClient extends AbstractCrawlerClient {
 
     @Override
     public void close() {
+        // Idempotency guard - the very first action, before touching worker, any Page monitor, or
+        // INITIALIZATION_LOCK. If another thread already began closing this instance, return
+        // immediately as a no-op: that thread tears down exactly once (single-threaded from here) and
+        // already waits for any in-flight execute(); a second concurrent close() has no useful work to
+        // do, and duplicating the shared-refcount decrement is the bug this guard prevents. Do NOT
+        // block waiting for the winner. Reset by init() so a re-init()'d instance can be closed again.
+        if (!closeInvoked.compareAndSet(false, true)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("close() already invoked on this instance, skipping");
+            }
+            return;
+        }
+
         if (worker == null) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Worker already null, nothing to close");

--- a/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientConcurrencyTest.java
+++ b/src/test/java/org/codelibs/fess/crawler/client/http/PlaywrightClientConcurrencyTest.java
@@ -579,6 +579,107 @@ public class PlaywrightClientConcurrencyTest extends PlainTestCase {
         }
     }
 
+    /**
+     * Test that TWO threads calling {@code close()} on the SAME shared-worker instance at the same
+     * time decrement the shared reference count exactly once.
+     *
+     * <p>Without the {@code closeInvoked} idempotency guard, both closer threads could pass the plain
+     * {@code worker == null} check before either nulled the field and each decrement
+     * {@code SHARED_WORKER_REF_COUNT}, driving it from 2 to 0 and tearing down the shared
+     * page/context/browser that the sibling instance ({@code client2}) is still actively using (and/or
+     * NPE-ing on the second thread's now-nulled {@code worker}). A {@code CountDownLatch} releases both
+     * closer threads at (nearly) the same instant to maximize overlap.</p>
+     *
+     * <p>Assertions: (a) neither concurrent {@code close()} threw an unexpected exception, and (b) the
+     * refcount was decremented only once - proven by {@code client2} still serving a request
+     * successfully afterward, i.e. its shared worker was NOT torn down prematurely.</p>
+     */
+    @Test
+    @Timeout(30)
+    public void test_sharedClient_concurrentDuplicateClose_decrementsRefCountOnce() throws Exception {
+        final MimeTypeHelper mimeTypeHelper = new MimeTypeHelperImpl();
+        final Map<String, Object> paramMap = new HashMap<>();
+        paramMap.put("sharedClient", Boolean.TRUE);
+
+        final PlaywrightClient client1 = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+        };
+
+        final PlaywrightClient client2 = new PlaywrightClient() {
+            @Override
+            protected Optional<MimeTypeHelper> getMimeTypeHelper() {
+                return Optional.ofNullable(mimeTypeHelper);
+            }
+        };
+
+        final ExecutorService executor = Executors.newFixedThreadPool(2, r -> {
+            final Thread thread = new Thread(r, "concurrent-close");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        try {
+            client1.setInitParameterMap(paramMap);
+            client1.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            client1.setCloseTimeout(5);
+            client1.init();
+
+            client2.setInitParameterMap(paramMap);
+            client2.setLaunchOptions(new BrowserType.LaunchOptions().setHeadless(HEADLESS));
+            client2.setCloseTimeout(5);
+            client2.init();
+
+            final int numClosers = 2;
+            final CountDownLatch ready = new CountDownLatch(numClosers);
+            final CountDownLatch go = new CountDownLatch(1);
+            final CountDownLatch done = new CountDownLatch(numClosers);
+            final AtomicReference<Throwable> unexpectedError = new AtomicReference<>();
+
+            for (int i = 0; i < numClosers; i++) {
+                executor.submit(() -> {
+                    try {
+                        ready.countDown();
+                        go.await(); // release both closers at (nearly) the same instant
+                        client1.close();
+                    } catch (final Throwable t) {
+                        unexpectedError.set(t);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+            go.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS));
+
+            // (a) Neither concurrent close() threw (e.g. an NPE from reading an already-nulled worker).
+            if (unexpectedError.get() != null) {
+                throw new AssertionError("A concurrent close() threw unexpectedly", unexpectedError.get());
+            }
+
+            // (b) The shared refcount was decremented exactly once (2 -> 1, not 2 -> 0): client2's
+            // shared page/context/browser was NOT torn down, so it must still serve requests.
+            final String url = "http://[::1]:" + SERVER_PORT + "/";
+            assertEquals(200, client2.execute(RequestDataBuilder.newRequestData().get().url(url).build()).getHttpStatusCode());
+        } finally {
+            executor.shutdownNow();
+            try {
+                client1.close();
+            } catch (final Exception e) {
+                // ignore
+            }
+            try {
+                client2.close();
+            } catch (final Exception e) {
+                // ignore
+            }
+        }
+    }
+
     // ==================== Stress tests ====================
 
     /**


### PR DESCRIPTION
## Summary
- Follow-up from #50's review: calling `close()` twice concurrently on the SAME shared-worker `PlaywrightClient` instance could let both threads pass the plain `worker == null` check before either nulled the field, so both would decrement the shared reference count - driving it to zero prematurely (tearing down a shared page/browser a sibling instance is still using) and/or NPE-ing on the second thread's now-nulled `worker`. Narrow, API-misuse-only scenario (the supported pattern is one owner thread per instance), but cheap to close for defense-in-depth.
- Added an `AtomicBoolean closeInvoked` latch, flipped via `compareAndSet` as the very first action in `close()` - before touching `worker`, any `Page` monitor, or `INITIALIZATION_LOCK`. A losing concurrent caller returns immediately as a no-op rather than duplicating any teardown work. Reset by `init()` (alongside the existing `closed` flag) so a re-init()'d instance can be closed again.
- Preserves the documented lock-ordering invariant (Page monitor before `INITIALIZATION_LOCK`) - the guard adds no new lock and the winning thread's path is unchanged.

## Test plan
- [x] Added `PlaywrightClientConcurrencyTest#test_sharedClient_concurrentDuplicateClose_decrementsRefCountOnce` - two threads race `close()` on the same shared-worker instance via `CountDownLatch`; asserts neither throws and a sibling shared-worker instance still serves requests afterward (proving the refcount was decremented exactly once, not twice)
- [x] Discrimination check: temporarily reverted only the guard with the new test in place - 7/12 runs failed with the exact predicted `NullPointerException` on the second thread's already-nulled `worker`; reinstating the guard makes it pass deterministically
- [x] Existing `test_sharedClient_duplicateClose` (sequential double-close), `test_concurrentInitExecuteClose_mixedSharedAndNonShared_noDeadlock` (deadlock guardrail), and `test_close_duringInFlightExecute_waitsThenClosesSafely` (#50's fix) all still pass
- [x] `mvn test` - 194/194 passing